### PR TITLE
Improve EnhancedSwitch input/label accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "material-ui-build",
   "private": true,
   "author": "Material-UI Team",
-  "version": "0.20.4",
+  "version": "0.20.8",
   "description": "React Components that Implement Google's Material Design.",
   "main": "./src/index.js",
   "keywords": [
@@ -53,6 +53,7 @@
     "keycode": "^2.1.8",
     "lodash.merge": "^4.6.0",
     "lodash.throttle": "^4.1.1",
+    "lodash.uniqueid": "^4.0.1",
     "prop-types": "^15.5.7",
     "react-event-listener": "^0.6.2",
     "react-transition-group": "^1.2.1",

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';
+import uniqueId from 'lodash.uniqueid';
 import transitions from '../styles/transitions';
 import FocusRipple from './FocusRipple';
 import TouchRipple from './TouchRipple';
@@ -297,8 +298,12 @@ class EnhancedSwitch extends Component {
       wrapStyles.marginRight /= 2;
     }
 
+    const id = other.id || uniqueId(name);
+
     const labelElement = label && (
-      <label style={prepareStyles(Object.assign(styles.label, labelStyle))}>
+      <label
+        htmlFor={id}
+        style={prepareStyles(Object.assign(styles.label, labelStyle))}>
         {label}
       </label>
     );
@@ -343,6 +348,7 @@ class EnhancedSwitch extends Component {
     const inputElement = (
       <input
         {...other}
+        id={id}
         ref="checkbox"
         type={inputType}
         style={prepareStyles(Object.assign(styles.input, inputStyle))}


### PR DESCRIPTION
Right now the labels of switches like checkboxes aren't properly associated with their inputs. This is bad for accessibility and also makes it inconvenient when writing cypress tests for checkboxes since you have to add a data-cy or aria-label every time.

This change generates an ID for inputs and adds `for` to the label. We could've used the `name` for the `id` and `for` but generating an ID avoids the case where a page could have two fields with the same `name`.

When we upgrade checkboxes to material v4 this won't be needed anymore since it properly puts inputs inside labels.

Refs: #CAKE-543